### PR TITLE
raise InconsistentWCSError if the wcs is inconsistent

### DIFF
--- a/asdf_astropy/converters/wcs/tests/test_wcs.py
+++ b/asdf_astropy/converters/wcs/tests/test_wcs.py
@@ -6,11 +6,10 @@ from astropy.io import fits
 from astropy.utils.data import get_pkg_data_filename, get_pkg_data_filenames
 from astropy.wcs import WCS, DistortionLookupTable, FITSFixedWarning, Sip
 
+from asdf_astropy.exceptions import InconsistentWCSError
 from asdf_astropy.testing.helpers import assert_wcs_roundtrip
 
-_astropy_test_header_filenames = list(get_pkg_data_filenames("tests/data/maps", "astropy.wcs", "*.hdr")) + list(
-    get_pkg_data_filenames("tests/data/spectra", "astropy.wcs", "*.hdr"),
-)
+_astropy_test_header_filenames = list(get_pkg_data_filenames("tests/data/maps", "astropy.wcs", "*.hdr"))
 
 _astropy_test_fits_filenames = [
     get_pkg_data_filename(f"tests/data/{fn}", "astropy.wcs")
@@ -118,3 +117,11 @@ def test_astropy_data_fits_roundtrip(fn, tmp_path, version):
             wcs = WCS(ff[0].header, ff)
 
         assert_wcs_roundtrip(wcs, tmp_path, version)
+
+
+@pytest.mark.parametrize("attr", ["pixel_shape", "pixel_bounds"])
+def test_failure_to_convert_inconsistent(tmp_path, attr):
+    wcs = create_wcs_with_attrs()
+    wcs.naxis -= 1
+    with pytest.raises(InconsistentWCSError, match="does not match naxis"):
+        assert_wcs_roundtrip(wcs, tmp_path)

--- a/asdf_astropy/converters/wcs/wcs.py
+++ b/asdf_astropy/converters/wcs/wcs.py
@@ -1,8 +1,10 @@
 from asdf.extension import Converter
 
+from asdf_astropy.exceptions import InconsistentWCSError
+
 # These attributes don't end up in the hdulist and
 # instead will be stored in "attrs"
-_WCS_ATTRS = ("naxis", "pixel_shape", "colsel", "keysel", "key", "pixel_bounds")
+_WCS_ATTRS = ("naxis", "colsel", "keysel", "key", "pixel_bounds", "pixel_shape")
 
 
 class WCSConverter(Converter):
@@ -36,6 +38,16 @@ class WCSConverter(Converter):
         return wcs
 
     def to_yaml_tree(self, wcs, tag, ctx):
+        # Check that wcs is consistent. Astropy inconsistently checks
+        # that certain expected attributes match. We need to check this
+        # here to prevent writing inconsistent files that would be problematic
+        # to open.
+        if naxis := wcs.naxis:
+            for attr in ("pixel_shape", "pixel_bounds"):
+                if value := getattr(wcs, attr):
+                    if len(value) != naxis:
+                        msg = f"{attr} shape ({len(value)}) does not match naxis ({naxis})"
+                        raise InconsistentWCSError(msg)
         hdulist = wcs.to_fits(relax=True)
         attrs = {a: getattr(wcs, a) for a in _WCS_ATTRS if hasattr(wcs, a)}
         return {"hdulist": hdulist, "attrs": attrs}


### PR DESCRIPTION
This PR checks the WCS for inconsistency on write and raises a new exception `InconsistentWCSError`. I removed testing against the https://github.com/astropy/astropy/tree/main/astropy/wcs/tests/data/spectra headers since they are all inconsistent.